### PR TITLE
Redundant Regex

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -183,7 +183,6 @@ const secondHalfOfRange = combine(
 	'-',
 	either(
 		/([a-z])/,
-		/(\d+)([a-z])/,
 		chapterAndVerse,
 		numberAndOptionalLetter
 	)


### PR DESCRIPTION
The numberAndOptionalLetter covers the /(\d+)([a-z])/ case in your example (if I'm not missing something). Also my first pull request, so this is a great experiment. To bad it is kinda overkill for this.